### PR TITLE
Adds machine ID identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,7 @@ func FileExists(fileName string) bool
 
 // Set values methods
 type Set[T comparable] map[T]struct{}
+
+// Machine ID
+func MachineID() string
 ```

--- a/pkg/mid/machineid_darwin.go
+++ b/pkg/mid/machineid_darwin.go
@@ -1,0 +1,31 @@
+package mid
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// MachineID - returns a string "{model number}|{serial number}|{hardware uuid}"
+func MachineID() string {
+	cmd := exec.Command("system_profiler", "SPHardwareDataType", "SPSecureElementDataType")
+	if output, err := cmd.Output(); err == nil {
+		var modelNumber, serialNumber, hardwareUUID string
+		for line := range strings.SplitSeq(string(output), "\n") {
+			if w := strings.Split(line, ":"); len(w) == 2 {
+				key := strings.TrimSpace(strings.ToLower(w[0]))
+				value := strings.TrimSpace(w[1])
+				switch key {
+				case "model number":
+					modelNumber = value
+				case "serial number":
+					serialNumber = value
+				case "hardware uuid":
+					hardwareUUID = value
+				}
+			}
+		}
+		return fmt.Sprintf("%s|%s|%s", modelNumber, serialNumber, hardwareUUID)
+	}
+	return ""
+}

--- a/pkg/mid/machineid_linux.go
+++ b/pkg/mid/machineid_linux.go
@@ -1,0 +1,50 @@
+package mid
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// MachineID in linux use hostnamectl, /var/lib/dbus/machine-id, or /etc/machine-id
+func MachineID() string {
+	if c, err := collectHostnamectl(); err == nil {
+		return c
+	}
+	if c, err := collectDbusMachineId(); err == nil {
+		return c
+	}
+	if c, err := collectEtcMachineId(); err == nil {
+		return c
+	}
+	return ""
+}
+
+func collectHostnamectl() (string, error) {
+	cmd := exec.Command("hostnamectl", "status")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(string(output), "\n") {
+		if w := strings.Split(line, ":"); len(w) == 2 && strings.TrimSpace(strings.ToLower(w[0])) == "machine id" {
+			return strings.TrimSpace(w[1]), nil
+		}
+	}
+	return "", errors.New("hostnamectl")
+}
+
+func collectDbusMachineId() (string, error) {
+	if content, err := os.ReadFile("/var/lib/dbus/machine-id"); err == nil {
+		return string(content), nil
+	}
+	return "", errors.New("dbus")
+}
+
+func collectEtcMachineId() (string, error) {
+	if content, err := os.ReadFile("/etc/machine-id"); err == nil {
+		return string(content), nil
+	}
+	return "", errors.New("etc")
+}

--- a/pkg/mid/machineid_test.go
+++ b/pkg/mid/machineid_test.go
@@ -1,0 +1,13 @@
+package mid_test
+
+import (
+	"testing"
+
+	"github.com/guionardo/go/pkg/mid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMachineID(t *testing.T) {
+	got := mid.MachineID()
+	assert.NotEmpty(t, got)
+}

--- a/pkg/mid/machineid_windows.go
+++ b/pkg/mid/machineid_windows.go
@@ -1,0 +1,56 @@
+package mid
+
+import (
+	"os/exec"
+	"regexp"
+)
+
+// reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient
+
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient
+//     CabSessionAfterSize    REG_DWORD    0x5000
+//     WinSqmFirstSessionStartTime    REG_QWORD    0x1db1cffbcda2a23
+//     MachineId    REG_SZ    {B43D4F72-6478-46AA-AB85-25686B1FA81D}
+
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\CommonUploader
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\IE
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\Windows
+const pattern = `MachineId\s+REG_SZ\s+\{([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})\}`
+
+var re = regexp.MustCompile(pattern)
+
+// MachineID returns the MachineID from registry SQMClient
+func MachineID() string {
+	cmd := exec.Command("reg", "query", `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient`)
+	if output, err := cmd.Output(); err == nil {
+		match := re.FindStringSubmatch(string(output))
+		if len(match) > 1 {
+			return match[1]
+		}
+	}
+	return ""
+}
+
+// func main() {
+// 	registryData := `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient
+//     CabSessionAfterSize    REG_DWORD    0x5000
+//     WinSqmFirstSessionStartTime    REG_QWORD    0x1db1cffbcda2a23
+//     MachineId    REG_SZ    {B43D4F72-6478-46AA-AB85-25686B1FA81D}
+
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\CommonUploader
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\IE
+// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\Windows`
+
+// 	// Regex pattern to match MachineId and extract the GUID value
+// 	pattern := `MachineId\s+REG_SZ\s+(\{[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}\})`
+
+// 	re := regexp.MustCompile(pattern)
+// 	match := re.FindStringSubmatch(registryData)
+
+// 	if len(match) > 1 {
+// 		machineId := match[1]
+// 		fmt.Printf("MachineId: %s\n", machineId)
+// 	} else {
+// 		fmt.Println("MachineId not found")
+// 	}
+// }


### PR DESCRIPTION
Adds reading machine ID

* Linux: hostnamectl, /var/lib/dbus/machine-id, or /etc/machine-id
* Windows: registry SQMClient
* MacOS: {model number}|{serial number}|{hardware uuid}