### PR TITLE
fix(mockhandler): rebuild body after no match

### DIFF
--- a/httptest_mock/mock_request.go
+++ b/httptest_mock/mock_request.go
@@ -189,6 +189,8 @@ func (m *Request) matchBody(r *http.Request) bool {
 
 	if !compareBody(m.Body, body) {
 		m.matchLog = append(m.matchLog, fmt.Sprintf("%s BODY %s != %s", noMatchEmoji, body, m.Body))
+		// if body does not match, must replace the body so it can be read again
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
 		return false
 	}
 


### PR DESCRIPTION
After a reading the body of the request must be rebuilt to be usable again.